### PR TITLE
Return request buffer from `llm-request-async'

### DIFF
--- a/llm-request.el
+++ b/llm-request.el
@@ -151,7 +151,8 @@ the buffer is turned into JSON and passed to ON-SUCCESS."
           (setq llm-request--partial-callback on-partial)
           (add-hook 'after-change-functions
                     #'llm-request--handle-new-content
-                    nil t))))))
+                    nil t)))
+      buffer)))
 
 ;; This is a useful method for getting out of the request buffer when it's time
 ;; to make callbacks.


### PR DESCRIPTION
Return request buffer from `llm-request-async`, allowing the user can cancel the request by killing the buffer. This will, in turn, kill the and cancel HTTP request.

I've tested this with Ollama and it appears to kill the underlying request as well.

fixes #6