### PR TITLE
Use split-string instead of string-split in llm-fake

### DIFF
--- a/llm-fake.el
+++ b/llm-fake.el
@@ -89,7 +89,7 @@ message cons. If nil, the response will be a simple vector."
               (setq accum (concat accum word " "))
               (funcall partial-callback accum)
               (sleep-for 0 100))
-            (string-split text))
+            (split-string text))
       (setf (llm-chat-prompt-interactions prompt)
             (append (llm-chat-prompt-interactions prompt)
                     (list (make-llm-chat-prompt-interaction :role 'assistant :content text))))


### PR DESCRIPTION
This fixes compatibility with emacs 28. Also, @ahyatt would you like to setup github actions to automate some checks? I can provide PR.