### PR TITLE
Vertex streaming and buffer killing

### DIFF
--- a/llm-vertex.el
+++ b/llm-vertex.el
@@ -316,7 +316,7 @@ If STREAMING is non-nil, use the URL for the streaming API."
         (streamed-text "")
         (function-call nil))
     (llm-request-plz-json-array
-     (llm-vertex--chat-url provider)
+     (llm-vertex--chat-url provider t)
      :headers `(("Authorization" . ,(format "Bearer %s" (llm-vertex-key provider))))
      :data (llm-vertex--chat-request prompt)
      :on-element (lambda (element)


### PR DESCRIPTION
Hi @ahyatt,

here's another PR. The Vertex provider wasn't using the streaming endpoint. Now it does, and the tester ran successfully with it.

The other change is that I'm now killing the response buffer when the request is complete. There is however one situation where I don't know how to do this: For sync requests that raise an exception. The error thrown does not have any handle to that buffer. I removed the change to adds the process to the plz-response. That could have gave us access to the process buffer.

