### PR TITLE
Error handling & JSON parsing

### DIFF
--- a/llm-gemini.el
+++ b/llm-gemini.el
@@ -65,7 +65,6 @@ You can get this at https://makersuite.google.com/app/apikey."
   (let ((buf (current-buffer)))
     (llm-request-plz-async (llm-gemini--embedding-url provider)
                            :data (llm-gemini--embedding-request provider string)
-                           :media-type '(application/json)
                            :on-success (lambda (data)
                                          (llm-request-callback-in-buffer
                                           buf vector-callback (llm-gemini--embedding-response-handler data)))
@@ -112,7 +111,6 @@ If STREAMING-P is non-nil, use the streaming endpoint."
   (let ((buf (current-buffer)))
     (llm-request-plz-async (llm-gemini--chat-url provider nil)
                            :data (llm-gemini--chat-request prompt)
-                           :media-type '(application/json)
                            :on-success (lambda (data)
                                          (llm-request-callback-in-buffer
                                           buf response-callback

--- a/llm-gemini.el
+++ b/llm-gemini.el
@@ -147,7 +147,10 @@ If STREAMING-P is non-nil, use the streaming endpoint."
                      provider prompt (or function-call
                                          (if (> (length streamed-text) 0)
                                              streamed-text
-                                           (llm-vertex--get-chat-response data)))))))))
+                                           (llm-vertex--get-chat-response data))))))
+     :on-error (lambda (_ data)
+                 (llm-request-callback-in-buffer buf error-callback 'error
+                                                 (llm-vertex--error-message data))))))
 
 (defun llm-gemini--count-token-url (provider)
   "Return the URL for the count token call, using PROVIDER."

--- a/llm-ollama.el
+++ b/llm-ollama.el
@@ -86,7 +86,6 @@ PROVIDER is the llm-ollama provider."
   (let ((buf (current-buffer)))
     (llm-request-plz-async (llm-ollama--url provider "embeddings")
                            :data (llm-ollama--embedding-request provider string)
-                           :media-type '(application/json)
                            :on-success (lambda (data)
                                          (llm-request-callback-in-buffer
                                           buf vector-callback (llm-ollama--embedding-extract-response data)))
@@ -148,7 +147,6 @@ STREAMING is a boolean to control whether to stream the response."
     (llm-request-plz-async
      (llm-ollama--url provider "chat")
      :data (llm-ollama--chat-request provider prompt nil)
-     :media-type '(application/json)
      :timeout llm-ollama-chat-timeout
      :on-success (lambda (data)
                    (let ((output (llm-ollama--get-response data)))

--- a/llm-openai.el
+++ b/llm-openai.el
@@ -116,7 +116,6 @@ This is just the key, if it exists."
   (llm-openai--check-key provider)
   (let ((buf (current-buffer)))
     (llm-request-plz-async (llm-openai--url provider "embeddings")
-                           :media-type '(application/json)
                            :headers (llm-openai--headers provider)
                            :data (llm-openai--embedding-request (llm-openai-embedding-model provider) string)
                            :on-success (lambda (data)
@@ -229,7 +228,6 @@ PROMPT is the prompt that needs to be updated with the response."
   (let ((buf (current-buffer)))
     (llm-request-plz-async
      (llm-openai--url provider "chat/completions")
-     :media-type '(application/json)
      :headers (llm-openai--headers provider)
      :data (llm-openai--chat-request (llm-openai-chat-model provider) prompt)
      :on-success (lambda (data)

--- a/llm-request-plz.el
+++ b/llm-request-plz.el
@@ -27,7 +27,7 @@
 (require 'rx)
 (require 'url-http)
 
-(defcustom llm-request-plz-timeout 60
+(defcustom llm-request-plz-timeout (* 2 60)
   "The number of seconds to wait for a response from a HTTP server.
 
 Request timings are depending on the request. Requests that need

--- a/llm-vertex.el
+++ b/llm-vertex.el
@@ -130,7 +130,6 @@ KEY-GENTIME keeps track of when the key was generated, because the key must be r
      (llm-vertex--embedding-url provider)
      :headers `(("Authorization" . ,(format "Bearer %s" (llm-vertex-key provider))))
      :data `(("instances" . [(("content" . ,string))]))
-     :media-type '(application/json)
      :on-success (lambda (data)
                    (llm-request-callback-in-buffer
                     buf vector-callback (llm-vertex--embedding-extract-response data)))
@@ -302,7 +301,6 @@ If STREAMING is non-nil, use the URL for the streaming API."
      (llm-vertex--chat-url provider)
      :headers `(("Authorization" . ,(format "Bearer %s" (llm-vertex-key provider))))
      :data (llm-vertex--chat-request prompt)
-     :media-type '(application/json)
      :on-success (lambda (data)
                    (llm-request-callback-in-buffer
                     buf response-callback

--- a/llm-vertex.el
+++ b/llm-vertex.el
@@ -338,7 +338,10 @@ If STREAMING is non-nil, use the URL for the streaming API."
                      provider prompt (or function-call
                                          (if (> (length streamed-text) 0)
                                              streamed-text
-                                           (llm-vertex--get-chat-response data)))))))))
+                                           (llm-vertex--get-chat-response data))))))
+     :on-error (lambda (_ data)
+                 (llm-request-callback-in-buffer buf error-callback 'error
+                                                 (llm-vertex--error-message data))))))
 
 ;; Token counts
 ;; https://cloud.google.com/vertex-ai/docs/generative-ai/get-token-count

--- a/plz-event-source.el
+++ b/plz-event-source.el
@@ -405,7 +405,16 @@
    (events :documentation "Association list from event type to handler."
            :initarg :events
            :initform nil
-           :type list)))
+           :type list))
+  "A media type class that handles the processing of HTTP responses
+in the server sent events format.  The HTTP response is processed
+in a streaming way.  The :events slot of the class can be set to
+an association list from event type symbol to a handler function.
+Whenever a new event is parsed and emitted the handler for the
+corresponding event type will be called with two arguments, an
+instance of the underlying event source class and an event.  The
+body slot of the plz-response struct passed to the THEN and ELSE
+callbacks will always be set to nil.")
 
 (defvar-local plz-event-source--current nil
   "The event source of the current buffer.")

--- a/plz.el
+++ b/plz.el
@@ -755,6 +755,7 @@ argument passed to `plz--sentinel', which see."
         (pcase-exhaustive status
           ((or 0 "finished\n")
            ;; Curl exited normally: check HTTP status code.
+           (widen)
            (goto-char (point-min))
            (plz--skip-proxy-headers)
            (while (plz--skip-redirect-headers))


### PR DESCRIPTION
Hi @ahyatt,

I tried out the Vertex and OpenAI providers and run into 2 issues:

- The first one was that json-read-from-string was called on a plz-response object on success. On success the body of the response is already decoded, according to the media type that handled it, so we don't need this. 

- The other issue was with handling error objects in Vertext and Gemini. The :else callback of the json-array media type doesn't contain the error messages. The media type always streams back the objects in the JSON array via the :handlers. In case of errors, the Vertex and Gemini (I think, I don't have access to it) response is also an array, with the elements being the error objects.

The errors are now handled in the llm library, but as a user you see this message:

`error in process filter: Error calling the LLM: Problem calling GCloud Vertex AI: status: 400 message: Please ensure that multiturn requests alternate between user and model.`

The error is not important here. They come from a request failing an me trying again and Vertex getting upset the something is not in order. But the `error in process filter: ` is kind of bad. I'm wondering what I should do in the cases when a function running in the the process filter raises an error, and if this is even something the plz-media-type request function can/should do. From the point of view of the plz-media-type function everything is ok, it got an error response, parsed it correctly, delivered the events to the the handler. The handler decided to raise an exception which plz-media-type is unlikely able to handle. So, maybe the hanlder should not raise a user-error here? Or we should catch it in the llm library and just inform the user via a message?

Wdty?  

