### PR TITLE
Update media type and event source packages

### DIFF
--- a/llm-request-plz.el
+++ b/llm-request-plz.el
@@ -250,7 +250,7 @@ This is required.
                          :timeout timeout
                          :media-type
                          (cons 'text/event-stream
-                                (plz-media-type:text/event-stream
+                                (plz-event-source:text/event-stream
                                  ;; Convert so that each event handler gets the body, not the
                                  ;; `plz-response' itself.
                                  :events (mapcar


### PR DESCRIPTION
This PR updates the media type and event source packages. 

- I moved the decoding from the process filter to the media type. Not everything should be decoded, e.g. binary data, and some media types have a default encoding (text/event-stream is always UTF-8 for example).

- The plz-media-type:text/event-stream got renamed to plz-event-source:text/event-stream to reflect the package in which it is defined.

- Fixed some lint issues in the event source package