### PR TITLE
Add support for HTTP/HTTPS proxies

### DIFF
--- a/plz-event-source.el
+++ b/plz-event-source.el
@@ -1,4 +1,4 @@
-;;; plz-event-source.el --- Server Sent Event Source -*- lexical-binding: t; -*-
+;;; plz-event-source.el --- Plz Event Source -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2019-2023  Free Software Foundation, Inc.
 
@@ -306,12 +306,6 @@
   (dolist (event (reverse events))
     (plz-event-source--dispatch-event source event)))
 
-(defun plz-event-source--response-in-buffer-p ()
-  "Return non-nil the if point is looking at a HTTP response."
-  (save-excursion
-    (goto-char (point-min))
-    (re-search-forward plz-http-end-of-headers-regexp nil t)))
-
 ;; Buffer event source
 
 (defclass plz-event-source-buffer (plz-event-source)
@@ -333,10 +327,27 @@
       (plz-event-source--dispatch-events source events)
       (setf events nil))))
 
+(defun plz-event-source--skip-proxy-headers ()
+  "Skip proxy headers in current buffer."
+  (when (looking-at plz-http-response-status-line-regexp)
+    (let* ((status-code (string-to-number (match-string 2)))
+           (reason-phrase (match-string 3)))
+      (when (and (equal 200 status-code)
+                 (equal "Connection established" reason-phrase))
+        (re-search-forward "\r\n\r\n" nil t)))))
+
+(defun plz-event-source--skip-redirect-headers ()
+  "Skip HTTP redirect headers in current buffer."
+  (when (and (looking-at plz-http-response-status-line-regexp)
+             (member (string-to-number (match-string 2)) '(301 302 303 307 308)))
+    (re-search-forward "\r\n\r\n" nil t)))
+
 (defun plz-event-source--buffer-start-position ()
   "Return the start position of the current buffer."
   (save-excursion
     (goto-char (point-min))
+    (plz-event-source--skip-proxy-headers)
+    (while (plz-event-source--skip-redirect-headers))
     (re-search-forward plz-http-end-of-headers-regexp nil t)
     (point)))
 


### PR DESCRIPTION
This adds support for HTTP/HTTPS proxies. The code that was dealing with this in plz.el wasn't migrated and we did not had any tests for this. This should now be fixed. See:

- https://github.com/r0man/plz-media-type/pull/8
- https://github.com/r0man/plz-event-source/pull/5

It fixes the issue #48 reported by @theasp. He tested the code with Ollama behind a Squid proxy. I tested it with Vertex and OpenAI behind a tinyproxy.

https://github.com/ahyatt/llm/issues/48

It also removes the default `plz-timeout`, since this is going to be removed in the next version of plz. It should not affect us, since we already have a default that is set to nil.