### PR TITLE
Test properly for prompt functions, including compiled functions

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,4 +1,6 @@
-* Verseion 0.17.1
+* Version 0.17.2
+- Fix compiled functions not being evaluated in =llm-prompt=.
+* Version 0.17.1
 - Support Ollama function calling, for models which support it.
 - Make sure every model, even unknown models, return some value for ~llm-chat-token-limit~.
 - Add token count for llama3.1 model.

--- a/llm-prompt-test.el
+++ b/llm-prompt-test.el
@@ -154,6 +154,13 @@ to converge."
       (should (member 'a var2))
       (should (= 5 (+ (length var1) (length var2)))))))
 
+(ert-deftest llm-prompt-fill-with-compiled-function ()
+  (should (equal
+           (llm-prompt-fill-text "({{var1}})"
+                                 (make-prompt-test-llm)
+                                 :var1 (byte-compile (iter-lambda () (iter-yield 'a))))
+           "(a)")))
+
 (ert-deftest llm-prompt-fill-size-limit-after-initial-fill ()
   ;; After filling the intial var1 from a string, we don't have enough tokens to
   ;; do any more filling.

--- a/llm-prompt.el
+++ b/llm-prompt.el
@@ -120,8 +120,11 @@ Return an alist of variables to their corresponding markers."
     (nreverse results)))
 
 (defun llm-prompt--simple-var-p (var)
-  "Return t if VAR is a simple variable, not a possible function."
-  (and (not (functionp var))))
+  "Return t if VAR is a simple variable, not a possible function.
+
+Lists will be turned into generators, so they are not simple variables."
+  (and (not (functionp var))
+       (not (listp var))))
 
 (iter-defun llm-prompt--select-tickets (vars)
   "Return generator that select tickets and calls generators in VARS.

--- a/llm-prompt.el
+++ b/llm-prompt.el
@@ -121,7 +121,8 @@ Return an alist of variables to their corresponding markers."
 
 (defun llm-prompt--simple-var-p (var)
   "Return t if VAR is a simple variable, not a possible function."
-  (and (not (eq (type-of var) 'function))
+  (and (not (eq (type-of var) 'compiled-function))
+       (not (eq (type-of var) 'function))
        (not (eq (type-of var) 'cons))))
 
 (iter-defun llm-prompt--select-tickets (vars)

--- a/llm-prompt.el
+++ b/llm-prompt.el
@@ -121,9 +121,7 @@ Return an alist of variables to their corresponding markers."
 
 (defun llm-prompt--simple-var-p (var)
   "Return t if VAR is a simple variable, not a possible function."
-  (and (not (eq (type-of var) 'compiled-function))
-       (not (eq (type-of var) 'function))
-       (not (eq (type-of var) 'cons))))
+  (and (not (functionp var))))
 
 (iter-defun llm-prompt--select-tickets (vars)
   "Return generator that select tickets and calls generators in VARS.


### PR DESCRIPTION
The issue before is that `type-of` is just a bad way to understand if something is a function, and my way of using it didn't understand that compiled functions were not simple variables, which caused them to be inserted as is, instead of executing.

Fixes https://github.com/ahyatt/llm/issues/53