### PR TITLE
Fix temperature calculation for llm-openai

### DIFF
--- a/llm-openai.el
+++ b/llm-openai.el
@@ -162,7 +162,7 @@ STREAMING if non-nil, turn on response streaming."
     (push `("model" . ,(or (llm-openai-chat-model provider)
                            "gpt-3.5-turbo-0613")) request-alist)
     (when (llm-chat-prompt-temperature prompt)
-      (push `("temperature" . ,(/ (llm-chat-prompt-temperature prompt) 2.0)) request-alist))
+      (push `("temperature" . ,(* (llm-chat-prompt-temperature prompt) 2.0)) request-alist))
     (when (llm-chat-prompt-max-tokens prompt)
       (push `("max_tokens" . ,(llm-chat-prompt-max-tokens prompt)) request-alist))
     (when (llm-chat-prompt-functions prompt)


### PR DESCRIPTION
* llm-openai.el (llm-provider-chat-request): Fix temperature calculation.

For the llm package, temperatures range from 0 to 1.  For OpenAI, they range from 0 to 2.  For this reason, we should multiply rather than divide by 2 to translate from llm temperatures to OpenAI temperatures.