### PR TITLE
Only collect streaming function data when we have function calls

### DIFF
--- a/llm-provider-utils.el
+++ b/llm-provider-utils.el
@@ -323,8 +323,9 @@ return a list of `llm-chat-function-call' structs.")
         (llm-provider-utils-process-result
          provider prompt
          current-text
-         (llm-provider-collect-streaming-function-data
-          provider (nreverse fc)))))
+         (when fc
+           (llm-provider-collect-streaming-function-data
+            provider (nreverse fc))))))
      :on-error (lambda (_ data)
                  (llm-provider-utils-callback-in-buffer
                   buf error-callback 'error


### PR DESCRIPTION
This means that we don't have to worry about
`llm-provider-colelct-streaming-function-data` having to worry about results that contain no function calls.