### PR TITLE
Make streaming not repeatedly insert the same thing

### DIFF
--- a/llm.el
+++ b/llm.el
@@ -427,12 +427,17 @@ be passed to `llm-cancel-request'."
                     (with-current-buffer (marker-buffer start)
                       (save-excursion
                         (goto-char start)
-                        (let* ((current-text (buffer-substring-no-properties start end))
-                               (common-prefix (fill-common-string-prefix current-text text))
+                        (let* ((current-text
+                                (buffer-substring-no-properties start end))
+                               (common-prefix
+                                (fill-common-string-prefix current-text text))
                                (prefix-length (length common-prefix)))
+                          ;; Skip over common prefix of current text
+                          ;; and new text.
                           (when (> prefix-length 0)
                             (goto-char (+ start prefix-length)))
                           (delete-region (point) end)
+                          ;; Insert new text, minus common prefix.
                           (insert (substring text prefix-length)))))))
           (llm-chat-streaming provider prompt
                               (lambda (text) (insert-text text))

--- a/llm.el
+++ b/llm.el
@@ -427,8 +427,13 @@ be passed to `llm-cancel-request'."
                     (with-current-buffer (marker-buffer start)
                       (save-excursion
                         (goto-char start)
-                        (delete-region start end)
-                        (insert text)))))
+                        (let* ((current-text (buffer-substring-no-properties start end))
+                               (common-prefix (fill-common-string-prefix current-text text))
+                               (prefix-length (length common-prefix)))
+                          (when (> prefix-length 0)
+                            (goto-char (+ start prefix-length)))
+                          (delete-region (point) end)
+                          (insert (substring text prefix-length)))))))
           (llm-chat-streaming provider prompt
                               (lambda (text) (insert-text text))
                               (lambda (text) (insert-text text)


### PR DESCRIPTION
* llm.el (llm-chat-streaming-to-point): Ignore common prefix between streamed text and buffer contents.

The motivation is as follows: without this patch, when the streamed text gets long enough, the call to `(delete-region start end) (insert text)` causes the buffer position to reset, preventing the user from viewing parts of the buffer away from the stream.  Happy to clarify or illustrate if that would help.