### PR TITLE
Remove the debug logs output on streaming, to reduce log volume

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,7 @@
+* Version 0.17.3
+- More fixes with Claude and Ollama function calling conversation, thanks to Paul Nelson.
+- Make =llm-chat-streaming-to-point= more efficient, just inserting new text, thanks to Paul Nelson.
+- Don't output streaming information when =llm-debug= is true, since it tended to be overwhelming.
 * Version 0.17.2
 - Fix compiled functions not being evaluated in =llm-prompt=.
 - Use Ollama's new =embed= API instead of the obsolete one.

--- a/llm.el
+++ b/llm.el
@@ -390,7 +390,6 @@ be passed to `llm-cancel-request'."
   ;; We need to wrap the callbacks before we set llm-log to nil.
   (let* ((new-partial-callback (lambda (response)
                                  (when partial-callback
-                                   (llm--log 'api-receive-partial :provider provider :msg response)
                                    (let ((llm-log nil))
                                      (funcall partial-callback response)))))
          (new-response-callback (lambda (response)


### PR DESCRIPTION
The vast amount of data that we could output when streaming tended to drown out the more important data.

Also add previous commits to NEWS.org.