### PR TITLE
Fix breakage with Open AI's llm-chat-token-limit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,10 @@ jobs:
     - name: Check out the source code
       uses: actions/checkout@v4
 
+    - name: Byte-compile the project
+      run: |
+        eldev -dtT compile --warnings-as-errors
+
     - name: Lint the project
       run: |
         eldev -p -dtT lint

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,5 @@
+* Version 0.17.4
+- Fix problem with Open AI's =llm-chat-token-limit=.
 * Version 0.17.3
 - More fixes with Claude and Ollama function calling conversation, thanks to Paul Nelson.
 - Make =llm-chat-streaming-to-point= more efficient, just inserting new text, thanks to Paul Nelson.

--- a/llm-openai.el
+++ b/llm-openai.el
@@ -270,8 +270,8 @@ RESPONSE can be nil if the response is complete."
       4096)
      (t 4096))))
 
-(cl-defmethod llm-chat-token-limit ((_ llm-openai-compatible))
-  (llm-provider-utils-model-token-limit (llm-ollama-chat-model provider)))
+(cl-defmethod llm-chat-token-limit ((provider llm-openai-compatible))
+  (llm-provider-utils-model-token-limit (llm-openai-chat-model provider)))
 
 (cl-defmethod llm-capabilities ((_ llm-openai))
   (list 'streaming 'embeddings 'function-calls))

--- a/llm-tester.el
+++ b/llm-tester.el
@@ -262,8 +262,7 @@ of by calling the `describe_function' function."
 
 (defun llm-tester-function-calling-sync (provider)
   "Test that PROVIDER can call functions."
-  (let ((prompt (llm-tester-create-test-function-prompt))
-        (result (llm-chat provider (llm-tester-create-test-function-prompt))))
+  (let ((result (llm-chat provider (llm-tester-create-test-function-prompt))))
     (cond ((stringp result)
            (llm-tester-log
             "ERROR: Provider %s returned a string instead of a function result"


### PR DESCRIPTION
Also fix unused variable in llm-tester.

Add byte-compilation to the CI to catch issues like this in the future.