### PR TITLE
Fix Vertex and Open AI's parallel call tool use

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,5 +1,6 @@
 * Version 0.17.4
 - Fix problem with Open AI's =llm-chat-token-limit=.
+- Fix Open AI and Gemini's parallel function calling.
 * Version 0.17.3
 - More fixes with Claude and Ollama function calling conversation, thanks to Paul Nelson.
 - Make =llm-chat-streaming-to-point= more efficient, just inserting new text, thanks to Paul Nelson.

--- a/llm-claude.el
+++ b/llm-claude.el
@@ -56,24 +56,23 @@
                    ;; Claude requires max_tokens
                    ("max_tokens" . ,(or (llm-chat-prompt-max-tokens prompt) 4096))
                    ("messages" .
-                    ,(llm-claude--postprocess-messages
-                      (mapcar (lambda (interaction)
-                                `(("role" . ,(pcase (llm-chat-prompt-interaction-role interaction)
-                                               ('function 'user)
-                                               ('assistant 'assistant)
-                                               ('user 'user)))
-                                  ("content" .
-                                   ,(if (llm-chat-prompt-interaction-function-call-results interaction)
-                                        (mapcar (lambda (result)
-                                                  `(("type" . "tool_result")
-                                                    ("tool_use_id" .
-                                                     ,(llm-chat-prompt-function-call-result-call-id
-                                                       result))
-                                                    ("content" .
-                                                     ,(llm-chat-prompt-function-call-result-result result))))
-                                                (llm-chat-prompt-interaction-function-call-results interaction))
-                                      (llm-chat-prompt-interaction-content interaction)))))
-                              (llm-chat-prompt-interactions prompt))))))
+                    ,(mapcar (lambda (interaction)
+                               `(("role" . ,(pcase (llm-chat-prompt-interaction-role interaction)
+                                              ('function 'user)
+                                              ('assistant 'assistant)
+                                              ('user 'user)))
+                                 ("content" .
+                                  ,(if (llm-chat-prompt-interaction-function-call-results interaction)
+                                       (mapcar (lambda (result)
+                                                 `(("type" . "tool_result")
+                                                   ("tool_use_id" .
+                                                    ,(llm-chat-prompt-function-call-result-call-id
+                                                      result))
+                                                   ("content" .
+                                                    ,(llm-chat-prompt-function-call-result-result result))))
+                                               (llm-chat-prompt-interaction-function-call-results interaction))
+                                     (llm-chat-prompt-interaction-content interaction)))))
+                             (llm-chat-prompt-interactions prompt)))))
         (system (llm-provider-utils-get-system-prompt prompt)))
     (when (llm-chat-prompt-functions prompt)
       (push `("tools" . ,(mapcar (lambda (f) (llm-claude--tool-call f))

--- a/llm-claude.el
+++ b/llm-claude.el
@@ -50,80 +50,6 @@
     ("input_schema" . ,(llm-provider-utils-openai-arguments
                         (llm-function-call-args call)))))
 
-(defun llm-claude--postprocess-messages (messages)
-  "Post-process MESSAGES, as in `llm-provider-chat-request'.
-
-Currently this flattens consecutive user tool results, for reasons
-explained in the final couple sentences of URL
-`https://docs.anthropic.com/en/docs/build-with-claude/\
-tool-use#multiple-tool-example'
-
-Example input:
-
- (((\"role\" . user) (\"content\" . \"Compute 2+3 and 4+5.\"))
-  ((\"role\" . assistant)
-   (\"content\"
-    ((type . \"tool_use\") (id . \"toolu_017epyv32yDx5zwhNPVprRrQ\")
-     (name . \"add\") (input (a . 2) (b . 3)))
-    ((type . \"tool_use\") (id . \"toolu_01EPALH8MdwuWVxzX8ErNKWM\")
-     (name . \"add\") (input (a . 4) (b . 5)))))
-  ((\"role\" . user)
-   (\"content\"
-    ((\"type\" . \"tool_result\")
-     (\"tool_use_id\" . \"toolu_017epyv32yDx5zwhNPVprRrQ\")
-     (\"content\" . \"5\"))))
-  ((\"role\" . user)
-   (\"content\"
-    ((\"type\" . \"tool_result\")
-     (\"tool_use_id\" . \"toolu_01EPALH8MdwuWVxzX8ErNKWM\")
-     (\"content\" . \"9\")))))
-
-Example output:
-
- (((\"role\" . user) (\"content\" . \"Compute 2+3 and 4+5.\"))
-  ((\"role\" . assistant)
-   (\"content\"
-    ((type . \"tool_use\") (id . \"toolu_017epyv32yDx5zwhNPVprRrQ\")
-     (name . \"add\") (input (a . 2) (b . 3)))
-    ((type . \"tool_use\") (id . \"toolu_01EPALH8MdwuWVxzX8ErNKWM\")
-     (name . \"add\") (input (a . 4) (b . 5)))))
-  ((\"role\" . \"user\")
-   (\"content\"
-    ((\"type\" . \"tool_result\")
-     (\"tool_use_id\" . \"toolu_017epyv32yDx5zwhNPVprRrQ\")
-     (\"content\" . \"5\"))
-    ((\"type\" . \"tool_result\")
-     (\"tool_use_id\" . \"toolu_01EPALH8MdwuWVxzX8ErNKWM\")
-     (\"content\" . \"9\")))))"
-  (let ((result '())
-        (tool-results '()))
-    (dolist (message messages)
-      (let* ((role (alist-get "role" message nil nil #'equal))
-             (content (alist-get "content" message nil nil #'equal))
-             (is-tool-result
-              (and (equal role 'user)
-                   (listp content)
-                   (let ((type
-                          (alist-get "type" (car content) nil nil #'equal)))
-                     (equal type "tool_result")))))
-        (cond
-         (is-tool-result
-          (setq tool-results (append tool-results content)))
-
-         ;; End of segment of user tool-results
-         ((and (null is-tool-result) tool-results)
-          (push `(("role" . "user") ("content" . ,tool-results)) result)
-          (setq tool-results '())
-          (push message result))
-
-         (t
-          (push message result)))))
-
-    (when tool-results
-      (push `(("role" . "user") ("content" . ,tool-results)) result))
-
-    (nreverse result)))
-
 (cl-defmethod llm-provider-chat-request ((provider llm-claude) prompt stream)
   (let ((request `(("model" . ,(llm-claude-chat-model provider))
                    ("stream" . ,(if stream t :json-false))
@@ -137,13 +63,15 @@ Example output:
                                                ('assistant 'assistant)
                                                ('user 'user)))
                                   ("content" .
-                                   ,(if (llm-chat-prompt-interaction-function-call-result interaction)
-                                        `((("type" . "tool_result")
-                                           ("tool_use_id" .
-                                            ,(llm-chat-prompt-function-call-result-call-id
-                                              (llm-chat-prompt-interaction-function-call-result interaction)))
-                                           ("content" .
-                                            ,(llm-chat-prompt-interaction-content interaction))))
+                                   ,(if (llm-chat-prompt-interaction-function-call-results interaction)
+                                        (mapcar (lambda (result)
+                                                  `(("type" . "tool_result")
+                                                    ("tool_use_id" .
+                                                     ,(llm-chat-prompt-function-call-result-call-id
+                                                       result))
+                                                    ("content" .
+                                                     ,(llm-chat-prompt-function-call-result-result result))))
+                                                (llm-chat-prompt-interaction-function-call-results interaction))
                                       (llm-chat-prompt-interaction-content interaction)))))
                               (llm-chat-prompt-interactions prompt))))))
         (system (llm-provider-utils-get-system-prompt prompt)))

--- a/llm-provider-utils.el
+++ b/llm-provider-utils.el
@@ -564,6 +564,8 @@ be either FUNCALLS or TEXT."
 (defun llm-provider-utils-populate-function-results (provider prompt results-alist)
   "Append the results in RESULTS-ALIST to the prompt.
 
+PROMPT is the prompt to populate into.
+
 RESULTS-ALIST is a list of cons of function
 calls (`llm-provider-utils-function-call' structs) and their
 results.

--- a/llm-provider-utils.el
+++ b/llm-provider-utils.el
@@ -512,6 +512,9 @@ This returns a JSON object (a list that can be converted to JSON)."
 
 OUTPUT can be a string or a structure in the case of function calls.
 
+FUNC-RESULTS is a list of function results resulting from the LLM
+output, if any.
+
 ROLE will be `assistant' by default, but can be passed in for other roles."
   (setf (llm-chat-prompt-interactions prompt)
         (append (llm-chat-prompt-interactions prompt)
@@ -523,7 +526,7 @@ ROLE will be `assistant' by default, but can be passed in for other roles."
                        :content (if (listp output)
                                     output
                                   (format "%s" output))
-                       :function-call-result func-results)))))
+                       :function-call-results func-results)))))
 
 (cl-defstruct llm-provider-utils-function-call
   "A struct to hold information about a function call.
@@ -547,25 +550,32 @@ be either FUNCALLS or TEXT."
   (if-let ((funcalls funcalls))
       ;; If we have function calls, execute them and return the results, and
       ;; it talso takes care of updating the prompt.
-      (llm-provider-utils-execute-function-calls provider prompt funcalls)
+      (let ((results-alist
+             (llm-provider-utils-execute-function-calls provider prompt funcalls)))
+        (llm-provider-utils-populate-function-results
+         provider prompt results-alist)
+        (mapcar #'cdr results-alist))
     ;; We probably shouldn't be called if text is nil, but if we do,
     ;; we shouldn't add something invalid to the prompt.
     (when text
       (llm-provider-append-to-prompt provider prompt text))
     text))
 
-(defun llm-provider-utils-populate-function-results (provider prompt func result)
-  "Append the RESULT of FUNC to PROMPT.
+(defun llm-provider-utils-populate-function-results (provider prompt results-alist)
+  "Append the results in RESULTS-ALIST to the prompt.
 
-FUNC is a `llm-provider-utils-function-call' struct.
+RESULTS-ALIST is a list of cons of function
+calls (`llm-provider-utils-function-call' structs) and their
+results.
 
 PROVIDER is the struct that configures the user of the LLM."
   (llm-provider-append-to-prompt
-   provider prompt result
-   (make-llm-chat-prompt-function-call-result
-    :call-id (llm-provider-utils-function-call-id func)
-    :function-name (llm-provider-utils-function-call-name func)
-    :result result)))
+   provider prompt nil
+   (mapcar (lambda (c) (make-llm-chat-prompt-function-call-result
+                        :call-id (llm-provider-utils-function-call-id (car c))
+                        :function-name (llm-provider-utils-function-call-name (car c))
+                        :result (cddr c)))
+           results-alist)))
 
 (defun llm-provider-utils-execute-function-calls (provider prompt funcalls)
   "Execute FUNCALLS, a list of `llm-provider-utils-function-calls'.
@@ -581,31 +591,32 @@ function call, the result.
 This returns the response suitable for output to the client; a
 cons of functions called and their output."
   (llm-provider-populate-function-calls provider prompt funcalls)
-  (cl-loop for func in funcalls collect
-           (let* ((name (llm-provider-utils-function-call-name func))
-                  (arguments (llm-provider-utils-function-call-args func))
-                  (function (seq-find
-                             (lambda (f) (equal name (llm-function-call-name f)))
-                             (llm-chat-prompt-functions prompt))))
-             (cons name
-                   (let* ((args (cl-loop for arg in (llm-function-call-args function)
-                                         collect (cdr (seq-find (lambda (a)
-                                                                  (eq (intern
-                                                                       (llm-function-arg-name arg))
-                                                                      (car a)))
-                                                                arguments))))
-                          (result (apply (llm-function-call-function function) args)))
-                     (llm-provider-utils-populate-function-results
-                      provider prompt func result)
-                     (llm--log
-                      'api-funcall
-                      :provider provider
-                      :msg (format "%s --> %s"
-                                   (format "%S"
-                                           (cons (llm-function-call-name function)
-                                                 args))
-                                   (format "%s" result)))
-                     result)))))
+  (cl-loop
+   for func in funcalls collect
+   (cons
+    func
+    (let* ((name (llm-provider-utils-function-call-name func))
+           (arguments (llm-provider-utils-function-call-args func))
+           (function (seq-find
+                      (lambda (f) (equal name (llm-function-call-name f)))
+                      (llm-chat-prompt-functions prompt))))
+      (cons name
+            (let* ((args (cl-loop for arg in (llm-function-call-args function)
+                                  collect (cdr (seq-find (lambda (a)
+                                                           (eq (intern
+                                                                (llm-function-arg-name arg))
+                                                               (car a)))
+                                                         arguments))))
+                   (result (apply (llm-function-call-function function) args)))
+              (llm--log
+               'api-funcall
+               :provider provider
+               :msg (format "%s --> %s"
+                            (format "%S"
+                                    (cons (llm-function-call-name function)
+                                          args))
+                            (format "%s" result)))
+              result))))))
 
 
 ;; This is a useful method for getting out of the request buffer when it's time

--- a/llm-vertex.el
+++ b/llm-vertex.el
@@ -193,14 +193,16 @@ the key must be regenerated every hour."
                                             interaction))))
                              (if (eq 'function
                                      (llm-chat-prompt-interaction-role interaction))
-                                 (let ((fc (llm-chat-prompt-interaction-function-call-result interaction)))
-                                   `(((functionResponse
-                                       .
-                                       ((name . ,(llm-chat-prompt-function-call-result-function-name fc))
-                                        (response
-                                         .
-                                         ((name . ,(llm-chat-prompt-function-call-result-function-name fc))
-                                          (content . ,(llm-chat-prompt-function-call-result-result fc)))))))))
+                                 (mapcar (lambda (fc)
+                                           `(((functionResponse
+                                               .
+                                               ((name . ,(llm-chat-prompt-function-call-result-function-name fc))
+                                                (response
+                                                 .
+                                                 ((name . ,(llm-chat-prompt-function-call-result-function-name fc))
+                                                  (content . ,(llm-chat-prompt-function-call-result-result fc)))))))))
+                                         (llm-chat-prompt-interaction-function-call-results interaction))
+
                                (llm-chat-prompt-interaction-content interaction))))))
                (llm-chat-prompt-interactions prompt))))
    (when (llm-chat-prompt-functions prompt)
@@ -233,7 +235,6 @@ nothing to add, in which case it is nil."
 (cl-defmethod llm-provider-populate-function-calls ((_ llm-vertex) prompt calls)
   (llm-provider-utils-append-to-prompt
    prompt
-   ;; For Vertex there is just going to be one call
    (mapcar (lambda (fc)
              `((functionCall
                 .

--- a/llm.el
+++ b/llm.el
@@ -76,11 +76,11 @@ Use of this directly is deprecated, instead use `llm-make-chat-prompt'."
   "This defines a single interaction given as part of a chat prompt.
 ROLE can a symbol, of either `user', `assistant', or `function'.
 
-FUNCTION-CALL-RESULTS is a struct of type
+FUNCTION-CALL-RESULTS is a list of structs of type
 `llm-chat-prompt-function-call-results', which is only populated
-if `role' is `function'.  It stores the results of just one
-function call."
-  role content function-call-result)
+if `role' is `function'.  It stores the results of the function
+calls."
+  role content  function-call-results)
 
 (cl-defstruct llm-chat-prompt-function-call-result
   "This defines the result from a function call.


### PR DESCRIPTION
Change how we store in the prompt the results to support parallel calls.

This is an alternate fix for https://github.com/ahyatt/llm/issues/71, so undoes https://github.com/ahyatt/llm/pull/73 and makes a fix along the lines of what Paul Nelson speculated would be needed.