### PR TITLE
Handle plz-error-message error type

### DIFF
--- a/llm-request-plz.el
+++ b/llm-request-plz.el
@@ -113,6 +113,8 @@ TIMEOUT is the number of seconds to wait for a response."
                     (status (plz-response-status response))
                     (body (plz-response-body response)))
            (funcall on-error 'error body)))
+        ((plz-error-message error)
+         (funcall on-error 'error (plz-error-message error)))
         (t (user-error "Unexpected error: %s" error))))
 
 (cl-defun llm-request-plz-async (url &key headers data on-success media-type


### PR DESCRIPTION
In some cases, plz may return a `plz-error` that does not contain a response or curl error, but just an error message. I think this should be passed to the `:on-error` callback.

On a related note, I've noticed that I don't completely understand the error handling model of llm. Some providers seem to have a `llm-provider-chat-extract-error` function which expects structured errors and is also called in the `:on-error` callback inside of `(llm-chat-async 'llm-standard-chat-provider ...)`. But looking at the implementation of `llm-request-plz-async`, this callback will only ever be called with stringly data.

Maybe `llm-provider-chat-extract-error` should only be called in the `:on-success` callback? That would make more sense, if I correctly understand the code.