### PR TITLE
Add gemini-2.0-flash-thinking-exp, fix output selection

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,6 +1,6 @@
 * Version 0.20.0
 - Add ability to output according to a JSON spec.
-- Add Gemini 2.0 Flash and Llama 3.3 and QwQ models.
+- Add Gemini 2.0 Flash, Gemini 2.0 Flash Thinking, and Llama 3.3 and QwQ models.
 * Version 0.19.1
 - Fix Open AI context length sizes, which are mostly smaller than advertised.
 * Version 0.19.0

--- a/llm-models.el
+++ b/llm-models.el
@@ -128,6 +128,10 @@ REGEX is a regular expression that can be used to identify the model, uniquely (
     :context-length 1048576
     :regex "gemini-2\\.0-flash")
    (make-llm-model
+    :name "Gemini 2.0 Flash Thinking" :symbol 'gemini-2.0-flash-thinking
+    :context-length 32768
+    :regex "gemini-2\\.0-flash-thinking")
+   (make-llm-model
     :name "Gemini 1.5 Flash" :symbol 'gemini-1.5-flash
     :capabilities '(generation tool-use image-input audio-input video-input)
     :context-length 1048576

--- a/llm-vertex.el
+++ b/llm-vertex.el
@@ -153,7 +153,7 @@ the key must be regenerated every hour."
                              (assoc-default 'content
                                             (aref (assoc-default 'candidates response) 0)))))
                  (when parts
-                   (assoc-default 'text (aref parts 0))))))))
+                   (assoc-default 'text (aref parts (- (length parts) 1)))))))))
 
 (cl-defmethod llm-provider-extract-function-calls ((provider llm-google) response)
   (if (vectorp response)


### PR DESCRIPTION
Thinking models will output several texts, we need to take the last one.  Always take the last text for Vertex/Gemini models instead of the first one.