### PR TITLE
Corrected typos in Snowflake model names and symbols

### DIFF
--- a/llm-models.el
+++ b/llm-models.el
@@ -215,15 +215,15 @@ REGEX is a regular expression that can be used to identify the model, uniquely (
     :context-length 256
     :regex "all-minilm")
    (make-llm-model
-    :name "Snowflake Artic Embed" :symbol 'snowflake-artic-embed
+    :name "Snowflake Arctic Embed" :symbol 'snowflake-arctic-embed
     :capabilities '(embedding free-software)  ;; Apache license
     :context-length 8192
-    :regex "snowflake-artic-embed")
+    :regex "snowflake-arctic-embed")
    (make-llm-model
-    :name "Snowflake Artic Embed 2.0" :symbol 'snowflake-artic-embed2
+    :name "Snowflake Arctic Embed 2.0" :symbol 'snowflake-arctic-embed2
     :capabilities '(embedding free-software)  ;; Apache license
     :context-length 8192
-    :regex "snowflake-artic-embed2")
+    :regex "snowflake-arctic-embed2")
    (make-llm-model
     :name "Qwen 2.5" :symbol 'qwen-2.5
     :capabilities '(generation tool-use)  ;; Apache license for some variations only


### PR DESCRIPTION
Fixed typos in the model names and symbols for Snowflake Arctic Embed and its version 2.0. Changed "artic" to "arctic" consistently across the codebase.