### PR TITLE
Introduce llm-models-add, plus fix an issue with gemini 2.0 model

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,5 @@
+* Version 0.21.0
+- Add ~llm-models-add~ as a convenience method to add a model to the known list.
 * Version 0.20.0
 - Add ability to output according to a JSON spec.
 - Add Gemini 2.0 Flash, Gemini 2.0 Flash Thinking, and Llama 3.3 and QwQ models.

--- a/README.org
+++ b/README.org
@@ -108,13 +108,11 @@ When picking a chat or embedding model, anything can be used, as long as the ser
 
 #+begin_src emacs-lisp
 (require 'llm-models)
-(add-to-list
- 'llm-models
- (make-llm-model
-  :name "Mistral" :symbol 'mistral
-  :capabilities '(generation tool-use free-software)
-  :context-length 8192
-  :regex "mistral"))
+(llm-models-add
+ :name "Mistral" :symbol 'mistral
+ :capabilities '(generation tool-use free-software)
+ :context-length 8192
+ :regex "mistral"))
 #+end_src
 
 The =:regex= needs to uniquely identify the model passed in from a provider's chat or embedding model.

--- a/llm-models-test.el
+++ b/llm-models-test.el
@@ -29,7 +29,7 @@
   ;; the models to ensure that the first match is the unique match.
   (let ((models-names-to-test '("gpt-3.5-turbo-instructo" "gpt-4" "gpt-4o"
                                 "gemini-1.5-flash" "llama-3" "llama-3.1"
-                                "llama3" "llama3.1")))
+                                "llama3" "llama3.1" "gemini-2.0-flash-thinking")))
     (dolist (model-name models-names-to-test)
       (let ((model-forward (llm-models-match model-name))
             (model-reverse (let ((llm-models (reverse llm-models)))

--- a/llm-models.el
+++ b/llm-models.el
@@ -248,9 +248,29 @@ REGEX is a regular expression that can be used to identify the model, uniquely (
   "Return the model that matches NAME."
   (seq-find (lambda (model) (string-match-p (llm-model-regex model) (downcase name))) llm-models))
 
-(cl-defun llm-models-add (&keys name symbol capabilities context-length regex)
-  "Add a model to the list of models."
-  (push (make-llm-model :name name :symbol symbol :capabilities capabilities :context-length context-length :regex regex) llm-models))
+(cl-defun llm-models-add (&key name symbol capabilities context-length regex)
+  "Add a model to the list of models.
+
+NAME is the name of the model, appropriate for showing a user.
+
+SYMBOL is a symbol representing the model, which just needs to be a
+unique symbol, and can also be searched on.
+
+CAPABILITIES is a list of symbols representing the capabilities of the
+model.  See `llm-capabilities' for the potential list of supported
+capabilities.  This may have some capabilities not yet supported by the
+`llm-capabilities'.
+
+CONTEXT-LENGTH is the maximum length of the context that can be used as
+input.
+
+REGEX is a regular expression that will be used to identify the model
+uniquely, matched against the model specified by the user."
+  (push (make-llm-model :name name
+                        :symbol symbol
+                        :capabilities capabilities
+                        :context-length context-length
+                        :regex regex) llm-models))
 
 (provide 'llm-models)
 

--- a/llm-models.el
+++ b/llm-models.el
@@ -126,7 +126,7 @@ REGEX is a regular expression that can be used to identify the model, uniquely (
     :name "Gemini 2.0 Flash" :symbol 'gemini-2.0-flash
     :capabilities '(generation tool-use image-input audio-input video-input)
     :context-length 1048576
-    :regex "gemini-2\\.0-flash")
+    :regex "gemini-2\\.0-flash\\(-exp\\)?$")
    (make-llm-model
     :name "Gemini 2.0 Flash Thinking" :symbol 'gemini-2.0-flash-thinking
     :capabilities '(generation)
@@ -247,6 +247,10 @@ REGEX is a regular expression that can be used to identify the model, uniquely (
 (defun llm-models-match (name)
   "Return the model that matches NAME."
   (seq-find (lambda (model) (string-match-p (llm-model-regex model) (downcase name))) llm-models))
+
+(cl-defun llm-models-add (&keys name symbol capabilities context-length regex)
+  "Add a model to the list of models."
+  (push (make-llm-model :name name :symbol symbol :capabilities capabilities :context-length context-length :regex regex) llm-models))
 
 (provide 'llm-models)
 


### PR DESCRIPTION
This is in response to a request from the discussion at https://github.com/ahyatt/llm/discussions/134 by @s-kostyaev.  The user can add to the existing list of models via a function.  It was possible before as well, but this makes it more obvious, and adds a layer of indirection in case we want to introduce a new variable for just user-specified models.