### PR TITLE
Use "chat-model" as the name for "llm-open-compatible"

### DIFF
--- a/llm-openai.el
+++ b/llm-openai.el
@@ -357,6 +357,11 @@ RESPONSE can be nil if the response is complete."
   "Return the name of the provider."
   "Open AI")
 
+(cl-defmethod llm-name ((provider llm-openai-compatible))
+  "Return the name of the `llm-openai-compatible' PROVIDER."
+  (or (llm-openai-compatible-chat-model provider)
+      "Open AI Compatible"))
+
 (cl-defmethod llm-chat-token-limit ((provider llm-openai))
   (llm-provider-utils-model-token-limit (llm-openai-chat-model provider)))
 


### PR DESCRIPTION
Consider this `llm-openai-compatible`. `(llm-name provider)` gives "Open AI" which is very confusing, especially when I have another Open AI provider. 

```elisp
(make-llm-openai-compatible
  :url "https://api.deepseek.com/v1/"
  :chat-model "deepseek-chat"
  :key "...")
```

After this change, the below provider gives "deepseek-chat" instead of "Open AI" as the name.