### PR TITLE
Add the ability to return multiple outputs via a plist in llm calls

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,5 @@
+* Version 0.24.0
+- Add =multi-output= as an option, allowing all llm results to return, call, or stream multiple kinds of data via a plist.  This allows separating out reasoning, as well as optionally returning text as well as tool uses at the same time.
 * Version 0.23.1
 - Add Gemini 2.0 pro experimental model, default to 2.0 flash
 - Add Open AI's o3 mini model

--- a/README.org
+++ b/README.org
@@ -139,9 +139,9 @@ Client applications should require the =llm= package, and code against it.  Most
 
 For all callbacks, the callback will be executed in the buffer the function was first called from.  If the buffer has been killed, it will be executed in a temporary buffer instead.
 ** Main functions
-- ~llm-chat provider prompt~:  With user-chosen ~provider~ , and a ~llm-chat-prompt~ structure (created by ~llm-make-chat-prompt~), send that prompt to the LLM and wait for the string output.
-- ~llm-chat-async provider prompt response-callback error-callback~: Same as ~llm-chat~, but executes in the background.  Takes a ~response-callback~ which will be called with the text response.  The ~error-callback~ will be called in case of error, with the error symbol and an error message.
-- ~llm-chat-streaming provider prompt partial-callback response-callback error-callback~:  Similar to ~llm-chat-async~, but request a streaming response.  As the response is built up, ~partial-callback~ is called with the all the text retrieved up to the current point.  Finally, ~reponse-callback~ is called with the complete text.
+- ~llm-chat provider prompt multi-output~:  With user-chosen ~provider~ , and a ~llm-chat-prompt~ structure (created by ~llm-make-chat-prompt~), send that prompt to the LLM and wait for the string output.
+- ~llm-chat-async provider prompt response-callback error-callback multi-output~: Same as ~llm-chat~, but executes in the background.  Takes a ~response-callback~ which will be called with the text response.  The ~error-callback~ will be called in case of error, with the error symbol and an error message.
+- ~llm-chat-streaming provider prompt partial-callback response-callback error-callback multi-output~:  Similar to ~llm-chat-async~, but request a streaming response.  As the response is built up, ~partial-callback~ is called with the all the text retrieved up to the current point.  Finally, ~reponse-callback~ is called with the complete text.
 - ~llm-embedding provider string~: With the user-chosen ~provider~, send a string and get an embedding, which is a large vector of floating point values.  The embedding represents the semantic meaning of the string, and the vector can be compared against other vectors, where smaller distances between the vectors represent greater semantic similarity.
 - ~llm-embedding-async provider string vector-callback error-callback~: Same as ~llm-embedding~ but this is processed asynchronously. ~vector-callback~ is called with the vector embedding, and, in case of error, ~error-callback~ is called with the same arguments as in ~llm-chat-async~.
 - ~llm-batch-embedding provider strings~: same as ~llm-embedding~, but takes in a list of strings, and returns a list of vectors whose order corresponds to the ordering of the strings.
@@ -156,6 +156,16 @@ For all callbacks, the callback will be executed in the buffer the function was 
   - ~llm-chat-prompt-to-text prompt~: From a prompt, return a string representation.  This is not usually suitable for passing to LLMs, but for debugging purposes.
   - ~llm-chat-streaming-to-point provider prompt buffer point finish-callback~: Same basic arguments as ~llm-chat-streaming~, but will stream to ~point~ in ~buffer~.
   - ~llm-chat-prompt-append-response prompt response role~: Append a new response (from the user, usually) to the prompt.  The ~role~ is optional, and defaults to ~'user~.
+*** Return and multi-output
+The default return value is text except for when tools are called, in which case it is a record of the return values of the tools called.
+
+Models can potentially return many types of information, though, so the ~multi-output~ option was added to the ~llm-chat~ calls so that the single return value can instead be a plist that represents the various possible values.  In the case of ~llm-chat~, this plist is returned, in ~llm-chat-async~, it is passed to the success function.  In ~llm-chat-streaming~, it is passed to the success function, and each partial update will be a plist, with no guarantee that the same keys will always be present.
+
+The possible plist keys are:
+   - ~:text~ , for the main textual output.
+   - ~:reasoning~, for reasoning output, when the model separates it.
+   - ~:tool-uses~, the tools that the llm identified to be called, as a list of plists, with ~:name~ and ~:args~ values.
+   - ~:tool-results~, the results of calling the tools.
 *** JSON schema
 By using the ~response-format~ argument to ~llm-make-chat-prompt~, you can ask the LLM to return items according to a specified JSON schema, based on the [[https://json-schema.org][JSON Schema Spec]].  Not everything is supported, but the most commonly used parts are.  To specify the JSON schema, we use a plist-based approach.  JSON objects are defined with ~(:type object :properties (:<var1> <schema1> :<var2> <schema2> ... :<varn> <scheman>) :required (<req var1> ... <req varn>))~.  Arrays are defined with ~(:type array :items <schema>)~.  Enums are defined with ~(:enum [<val1> <val2> <val3>])~.  You can also request integers, strings, and other types defined by the JSON Schema Spec, by just having ~(:type <type>)~.  Typically, LLMs often require the top-level schema object to be an object, and often that all properties on the top-level object must be required.
 

--- a/llm-claude.el
+++ b/llm-claude.el
@@ -135,7 +135,7 @@
       (format "Unsupported non-text response: %s" content))))
 
 (cl-defmethod llm-provider-streaming-media-handler ((_ llm-claude)
-                                                    msg-receiver _ err-receiver)
+                                                    receiver err-receiver)
   (cons 'text/event-stream
         (plz-event-source:text/event-stream
          :events `((message_start . ignore)
@@ -153,7 +153,7 @@
                               (delta (assoc-default 'delta json))
                               (type (assoc-default 'type delta)))
                          (when (equal type "text_delta")
-                           (funcall msg-receiver (assoc-default 'text delta))))))))))
+                           (funcall receiver `(:text ,(assoc-default 'text delta)))))))))))
 
 (cl-defmethod llm-provider-collect-streaming-tool-uses ((_ llm-claude) data)
   (llm-provider-utils-openai-collect-streaming-tool-uses data))

--- a/llm-fake.el
+++ b/llm-fake.el
@@ -48,7 +48,9 @@ message cons.  If nil, the response will be a simple vector."
 
 (cl-defmethod llm-chat-async ((provider llm-fake) prompt response-callback error-callback &optional multi-output)
   (condition-case err
-      (funcall response-callback (llm-chat provider prompt multi-output))
+      ;; We use `apply' here in case `llm-chat is older and doesn't support
+      ;; the multi-output argument.
+      (funcall response-callback (apply #'llm-chat provider prompt multi-output))
     (t (funcall error-callback (car err) (cdr err))))
   nil)
 

--- a/llm-fake.el
+++ b/llm-fake.el
@@ -46,13 +46,13 @@ either a vector response for the chat, or a signal symbol and
 message cons.  If nil, the response will be a simple vector."
   output-to-buffer chat-action-func embedding-action-func)
 
-(cl-defmethod llm-chat-async ((provider llm-fake) prompt response-callback error-callback)
+(cl-defmethod llm-chat-async ((provider llm-fake) prompt response-callback error-callback &optional multi-output)
   (condition-case err
       (funcall response-callback (llm-chat provider prompt))
     (t (funcall error-callback (car err) (cdr err))))
   nil)
 
-(cl-defmethod llm-chat ((provider llm-fake) prompt)
+(cl-defmethod llm-chat ((provider llm-fake) prompt &optional multi-output)
   (when (llm-fake-output-to-buffer provider)
     (with-current-buffer (get-buffer-create (llm-fake-output-to-buffer provider))
       (goto-char (point-max))
@@ -71,7 +71,7 @@ message cons.  If nil, the response will be a simple vector."
                   (list (make-llm-chat-prompt-interaction :role 'assistant :content result))))
     result))
 
-(cl-defmethod llm-chat-streaming ((provider llm-fake) prompt partial-callback response-callback _error-callback)
+(cl-defmethod llm-chat-streaming ((provider llm-fake) prompt partial-callback response-callback _error-callback &optional multi-output)
   (when (llm-fake-output-to-buffer provider)
     (with-current-buffer (get-buffer-create (llm-fake-output-to-buffer provider))
       (goto-char (point-max))

--- a/llm-integration-test.el
+++ b/llm-integration-test.el
@@ -325,10 +325,14 @@ else.  We really just want to see if it's in the right ballpark."
 
 (llm-def-integration-test llm-tool-use-multi-result (provider)
   (when (member 'function-calls (llm-capabilities provider))
-    (let ((prompt (llm-integration-test-tool-use-prompt)))
+    (let* ((prompt (llm-integration-test-tool-use-prompt))
+           (result (llm-chat provider prompt t)))
       (should (equal
-               (llm-chat provider prompt)
-               '(:tool-results llm-integration-test-fc-answer)))
+               (plist-get result :tool-results)
+               llm-integration-test-fc-answer))
+      (should (plist-get result :tool-uses))
+      (if (plist-get result :text)
+          (should (> (length (plist-get result :text)) 0)))
       ;; Test that we can send the function back to the provider without error.
       (llm-chat provider prompt t))))
 

--- a/llm-integration-test.el
+++ b/llm-integration-test.el
@@ -328,7 +328,7 @@ else.  We really just want to see if it's in the right ballpark."
     (let ((prompt (llm-integration-test-tool-use-prompt)))
       (should (equal
                (llm-chat provider prompt)
-               (:tool-results llm-integration-test-fc-answer)))
+               '(:tool-results llm-integration-test-fc-answer)))
       ;; Test that we can send the function back to the provider without error.
       (llm-chat provider prompt t))))
 

--- a/llm-ollama.el
+++ b/llm-ollama.el
@@ -109,13 +109,25 @@ PROVIDER is the llm-ollama provider."
   (let ((raw-result (assoc-default 'content (assoc-default 'message response))))
     ;; The raw result may have reasoning content in, which is in <think> tags
     ;; (for DeepSeek reasoning).  We want to strip that out.
-    (replace-regexp-in-string "<think>.*</think>" "" raw-result)))
+    (with-temp-buffer
+      (insert raw-result)
+      (goto-char 0)
+      (if (search-forward "\n</think>" nil t)
+          (string-trim (buffer-substring (point) (point-max)))
+        raw-result))))
 
 (cl-defmethod llm-provider-extract-reasoning ((_ llm-ollama) response)
   (let ((raw-result (assoc-default 'content (assoc-default 'message response))))
     ;; Reasoning content is in <think> tags (for DeepSeek reasoning).  We want to
     ;; extract the content between these tags.
-    (replace-regexp-in-string "<think>\\(.*\\)</think>" "\\1" raw-result)))
+    (with-temp-buffer
+      (insert raw-result)
+      (goto-char 0)
+      (when (search-forward "<think>\n" nil t)
+        (let* ((endtag "\n</think>")
+               (end (save-excursion
+                      (search-forward endtag))))
+          (buffer-substring (point) (- end (length endtag))))))))
 
 (defun llm-ollama--response-format (format)
   "Return the response format for FORMAT."

--- a/llm-ollama.el
+++ b/llm-ollama.el
@@ -106,7 +106,16 @@ PROVIDER is the llm-ollama provider."
 
 (cl-defmethod llm-provider-chat-extract-result ((_ llm-ollama) response)
   "Return the chat response from the server RESPONSE."
-  (assoc-default 'content (assoc-default 'message response)))
+  (let ((raw-result (assoc-default 'content (assoc-default 'message response))))
+    ;; The raw result may have reasoning content in, which is in <think> tags
+    ;; (for DeepSeek reasoning).  We want to strip that out.
+    (replace-regexp-in-string "<think>.*</think>" "" raw-result)))
+
+(cl-defmethod llm-provider-extract-reasoning ((_ llm-ollama) response)
+  (let ((raw-result (assoc-default 'content (assoc-default 'message response))))
+    ;; Reasoning content is in <think> tags (for DeepSeek reasoning).  We want to
+    ;; extract the content between these tags.
+    (replace-regexp-in-string "<think>\\(.*\\)</think>" "\\1" raw-result)))
 
 (defun llm-ollama--response-format (format)
   "Return the response format for FORMAT."

--- a/llm-openai.el
+++ b/llm-openai.el
@@ -348,8 +348,10 @@ RESPONSE can be nil if the response is complete."
                          (unless (equal data "[DONE]")
                            (when-let ((response (llm-openai--get-partial-chat-response
                                                  (json-parse-string data :object-type 'alist))))
-                             (funcall receiver (list (if (stringp response) :text :tool-call)
-                                                     response)))))))))))
+                             (funcall receiver (if (stringp response)
+                                                   (list :text response)
+                                                 (list :tool-uses-raw
+                                                       response))))))))))))
 
 (cl-defmethod llm-provider-collect-streaming-tool-uses ((_ llm-openai) data)
   (llm-provider-utils-openai-collect-streaming-tool-uses data))

--- a/llm-openai.el
+++ b/llm-openai.el
@@ -338,7 +338,7 @@ RESPONSE can be nil if the response is complete."
                                  (assoc-default 'tool_calls delta)))))
       content-or-call)))
 
-(cl-defmethod llm-provider-streaming-media-handler ((_ llm-openai) msg-receiver fc-receiver _)
+(cl-defmethod llm-provider-streaming-media-handler ((_ llm-openai) receiver _)
   (cons 'text/event-stream
         (plz-event-source:text/event-stream
          :events `((message
@@ -348,7 +348,8 @@ RESPONSE can be nil if the response is complete."
                          (unless (equal data "[DONE]")
                            (when-let ((response (llm-openai--get-partial-chat-response
                                                  (json-parse-string data :object-type 'alist))))
-                             (funcall (if (stringp response) msg-receiver fc-receiver) response))))))))))
+                             (funcall receiver (list (if (stringp response) :text :tool-call)
+                                                     response)))))))))))
 
 (cl-defmethod llm-provider-collect-streaming-tool-uses ((_ llm-openai) data)
   (llm-provider-utils-openai-collect-streaming-tool-uses data))

--- a/llm-provider-utils-test.el
+++ b/llm-provider-utils-test.el
@@ -138,5 +138,15 @@
     (should (equal "Previous interactions:\n\nUser: Hello\nAssistant: Hi! How can I assist you?\n\nThe current conversation follows:\n\nEarl Grey, hot."
                    (llm-chat-prompt-interaction-content (nth 0 (llm-chat-prompt-interactions prompt-for-second-request)))))))
 
+(ert-deftest llm-provider-utils-streaming-accumulate ()
+  (should (equal 3 (llm-provider-utils-streaming-accumulate 1 2)))
+  (should (equal "foobar" (llm-provider-utils-streaming-accumulate "foo" "bar")))
+  (should (equal [1 2 3] (llm-provider-utils-streaming-accumulate [1] [2 3])))
+  (should (equal '(1 2 3) (llm-provider-utils-streaming-accumulate '(1) '(2 3))))
+  (should (equal (llm-test-normalize '(:foo "aa" :bar "b" :baz "c"))
+                 (llm-test-normalize (llm-provider-utils-streaming-accumulate '(:foo "a" :baz "c") '(:foo "a" :bar "b")))))
+  (should (equal '(:foo 3) (llm-provider-utils-streaming-accumulate '(:foo 1) '(:foo 2))))
+  (should (equal '(:foo "foo bar baz") (llm-provider-utils-streaming-accumulate '(:foo "foo bar") '(:foo " baz")))))
+
 (provide 'llm-provider-utils-test)
 ;;; llm-provider-utils-test.el ends here

--- a/llm-provider-utils.el
+++ b/llm-provider-utils.el
@@ -344,7 +344,7 @@ return a list of `llm-chat-prompt-tool-use' structs.")
     final-result))
 
 (cl-defmethod llm-chat-async ((provider llm-standard-chat-provider) prompt success-callback
-                              error-callback multi-output)
+                              error-callback &optional multi-output)
   (llm-provider-request-prelude provider)
   (let ((buf (current-buffer)))
     (llm-request-plz-async
@@ -408,7 +408,7 @@ Any strings will be concatenated, integers will be added, etc."
     new))
 
 (cl-defmethod llm-chat-streaming ((provider llm-standard-chat-provider) prompt partial-callback
-                                  response-callback error-callback multi-output)
+                                  response-callback error-callback &optional multi-output)
   (llm-provider-request-prelude provider)
   (let ((buf (current-buffer))
         (current-result))
@@ -423,7 +423,9 @@ Any strings will be concatenated, integers will be added, etc."
                           (llm-provider-utils-streaming-accumulate current-result s))
                     (when partial-callback
                       (llm-provider-utils-callback-in-buffer
-                       buf partial-callback current-result)))
+                       buf partial-callback (if multi-output
+                                                current-result
+                                              (plist-get current-result :text)))))
                   (lambda (err)
                     (llm-provider-utils-callback-in-buffer
                      buf error-callback 'error

--- a/llm-provider-utils.el
+++ b/llm-provider-utils.el
@@ -394,6 +394,7 @@ Any strings will be concatenated, integers will be added, etc."
               ('float (+ current new))
               ('vector (vconcat current new))
               ('cons (if (and (> (length current) 0)  ;; if plist
+                              (symbolp (car current))
                               (string-match-p "^:" (symbol-name (car current))))
                          (cl-loop for key in
                                   (seq-union (map-keys current)

--- a/llm-vertex.el
+++ b/llm-vertex.el
@@ -258,8 +258,7 @@ nothing to add, in which case it is nil."
   (llm-provider-utils-append-to-prompt prompt tool-uses nil 'assistant))
 
 (cl-defmethod llm-provider-streaming-media-handler ((provider llm-google)
-                                                    msg-receiver fc-receiver
-                                                    err-receiver)
+                                                    receiver err-receiver)
   (cons 'application/json
         (plz-media-type:application/json-array
          :handler
@@ -267,9 +266,9 @@ nothing to add, in which case it is nil."
            (when-let ((err-response (llm-provider-chat-extract-error provider element)))
              (funcall err-receiver err-response))
            (if-let ((response (llm-provider-chat-extract-result provider element)))
-               (funcall msg-receiver response)
+               (funcall receiver `(:text ,response))
              (when-let ((fc (llm-provider-extract-tool-uses provider element)))
-               (funcall fc-receiver fc)))))))
+               (funcall receiver `(:tool-call ,fc))))))))
 
 (cl-defmethod llm-provider-collect-streaming-tool-uses ((_ llm-google) data)
   (car data))

--- a/llm.el
+++ b/llm.el
@@ -342,7 +342,7 @@ need to override it."
   (ignore provider)
   nil)
 
-(cl-defgeneric llm-chat (provider prompt)
+(cl-defgeneric llm-chat (provider prompt &optional multi-output)
   "Return a response to PROMPT from PROVIDER.
 PROMPT is a `llm-chat-prompt'.
 
@@ -352,20 +352,26 @@ conses of the function named called (as a symbol), and the
 corresponding result from calling it.
 
 The prompt's interactions list will be updated to encode the
-conversation so far."
-  (ignore provider prompt)
+conversation so far.
+
+If MULTI-OUTPUT is non-nil the response is a plist with the possible
+keys: `text' (textual output), `reasoning' (reasoning that accompanies
+the output) `tool-uses' (an alist of tools and their arguments),
+`tool-results' (an alist of results of a calling tools), and
+`text-alternates', a list of alternate possibilities for the output."
+  (ignore provider prompt multi-output)
   (signal 'not-implemented nil))
 
-(cl-defmethod llm-chat ((_ (eql nil)) _)
+(cl-defmethod llm-chat ((_ (eql nil)) _ &optional _)
   "Catch trivial configuration mistake."
   (error "LLM provider was nil.  Please set the provider in the application you are using"))
 
-(cl-defmethod llm-chat :before (provider _)
+(cl-defmethod llm-chat :before (provider _ &optional _)
   "Issue a warning if the LLM is non-free."
   (when-let (info (llm-nonfree-message-info provider))
     (llm--warn-on-nonfree (llm-name provider) info)))
 
-(cl-defmethod llm-chat :around (provider prompt)
+(cl-defmethod llm-chat :around (provider prompt &optional _)
   "Log the input to llm-chat."
   (llm--log 'api-send :provider provider :prompt prompt)
   ;; We set the debug flag to nil around the next-method so that we don't log
@@ -378,7 +384,7 @@ conversation so far."
       (llm--log 'api-receive :provider provider :msg result))
     result))
 
-(cl-defgeneric llm-chat-async (provider prompt response-callback error-callback)
+(cl-defgeneric llm-chat-async (provider prompt response-callback error-callback &optional multi-output)
   "Call RESPONSE-CALLBACK with a response to PROMPT from PROVIDER.
 
 The response is a string response by the LLM when functions are
@@ -391,6 +397,12 @@ PROMPT is a `llm-chat-prompt'.
 RESPONSE-CALLBACK receives the final text.
 
 ERROR-CALLBACK receives the error response.
+
+If MULTI-OUTPUT is non-nil the response is a plist with the possible
+keys: `text' (textual output), `reasoning' (reasoning that accompanies
+the output) `tool-uses' (an alist of tools and their arguments),
+`tool-results' (an alist of results of a calling tools), and
+`text-alternates', a list of alternate possibilities for the output.
 
 The prompt's interactions list will be updated to encode the
 conversation so far.
@@ -405,9 +417,10 @@ be passed to `llm-cancel-request'."
                       nil
                       (lambda (text)
                         (funcall response-callback text))
-                      (lambda (err msg) (funcall error-callback err msg))))
+                      (lambda (err msg) (funcall error-callback err msg))
+                      multi-output))
 
-(cl-defmethod llm-chat-async :around (provider prompt response-callback error-callback)
+(cl-defmethod llm-chat-async :around (provider prompt response-callback error-callback &optional multi-output)
   "Log the input to llm-chat-async."
   (llm--log 'api-send :provider provider :prompt prompt)
   (let* ((new-response-callback (lambda (response)
@@ -422,10 +435,11 @@ be passed to `llm-cancel-request'."
          (llm-log nil)
          (result (cl-call-next-method provider prompt
                                       new-response-callback
-                                      new-error-callback)))
+                                      new-error-callback
+                                      multi-output)))
     result))
 
-(cl-defgeneric llm-chat-streaming (provider prompt partial-callback response-callback error-callback)
+(cl-defgeneric llm-chat-streaming (provider prompt partial-callback response-callback error-callback &optional multi-output)
   "Stream a response to PROMPT from PROVIDER.
 PROMPT is a `llm-chat-prompt'.
 
@@ -449,24 +463,29 @@ final text.
 
 ERROR-CALLBACK receives the error response.
 
+If MULTI-OUTPUT is non-nil the response is a plist with the possible
+keys: `text' (textual output), `reasoning' (reasoning that accompanies
+the output) `tool-results' (an alist of results of a calling tools) and
+`text-alternates', a list of alternate possibilities for the output.
+
 The prompt's interactions list will be updated to encode the
 conversation so far.
 
 This returns an object representing the async request, which can
 be passed to `llm-cancel-request'."
-  (ignore provider prompt partial-callback response-callback error-callback)
+  (ignore provider prompt partial-callback response-callback error-callback multi-output)
   (signal 'not-implemented nil))
 
-(cl-defmethod llm-chat-streaming ((_ (eql nil)) _ _ _ _)
+(cl-defmethod llm-chat-streaming ((_ (eql nil)) _ _ _ _ &optional _)
   "Catch trivial configuration mistake."
   (error "LLM provider was nil.  Please set the provider in the application you are using"))
 
-(cl-defmethod llm-chat-streaming :before (provider _ _ _ _)
+(cl-defmethod llm-chat-streaming :before (provider _ _ _ _ &optional _)
   "Issue a warning if the LLM is non-free."
   (when-let (info (llm-nonfree-message-info provider))
     (llm--warn-on-nonfree (llm-name provider) info)))
 
-(cl-defmethod llm-chat-streaming :around (provider prompt partial-callback response-callback error-callback)
+(cl-defmethod llm-chat-streaming :around (provider prompt partial-callback response-callback error-callback &optional multi-output)
   "Log the input to llm-chat-async."
   (llm--log 'api-send :provider provider :prompt prompt)
   ;; We need to wrap the callbacks before we set llm-log to nil.
@@ -486,7 +505,7 @@ be passed to `llm-cancel-request'."
          (llm-log nil)
          (result (cl-call-next-method provider prompt new-partial-callback
                                       new-response-callback
-                                      new-error-callback)))
+                                      new-error-callback multi-output)))
     result))
 
 (defun llm-chat-streaming-to-point (provider prompt buffer point finish-callback)
@@ -526,11 +545,11 @@ be passed to `llm-cancel-request'."
                                 (funcall finish-callback))
                               (lambda (_ msg) (error "Error calling the LLM: %s" msg))))))))
 
-(cl-defmethod llm-chat-async ((_ (eql nil)) _ _ _)
+(cl-defmethod llm-chat-async ((_ (eql nil)) _ _ _ &optional _)
   "Catch trivial configuration mistake."
   (error "LLM provider was nil.  Please set the provider in the application you are using"))
 
-(cl-defmethod llm-chat-async :before (provider _ _ _)
+(cl-defmethod llm-chat-async :before (provider _ _ _ &optional _)
   "Issue a warning if the LLM is non-free."
   (when-let (info (llm-nonfree-message-info provider))
     (llm--warn-on-nonfree (llm-name provider) info)))

--- a/llm.el
+++ b/llm.el
@@ -410,13 +410,17 @@ be passed to `llm-cancel-request'."
   ;; By default, you can turn a streaming call into an async call, so we can
   ;; fall back to streaming if async is not populated.
   ;; However, first, we don't want to log twice, so let's delete the last log so that llm-chat-streaming will
-  (llm-chat-streaming provider prompt
-                      ;; Do nothing on partial callback
-                      nil
-                      (lambda (text)
-                        (funcall response-callback text))
-                      (lambda (err msg) (funcall error-callback err msg))
-                      multi-output))
+  ;;
+  ;; We use `apply' here in case `llm-chat-streaming' is older and doesn't
+  ;; support the multi-output argument.
+  (apply #'llm-chat-streaming
+         provider prompt
+         ;; Do nothing on partial callback
+         nil
+         (lambda (text)
+           (funcall response-callback text))
+         (lambda (err msg) (funcall error-callback err msg))
+         multi-output))
 
 (cl-defmethod llm-chat-async :around (provider prompt response-callback error-callback &optional multi-output)
   "Log the input to llm-chat-async."

--- a/llm.el
+++ b/llm.el
@@ -356,9 +356,8 @@ conversation so far.
 
 If MULTI-OUTPUT is non-nil the response is a plist with the possible
 keys: `text' (textual output), `reasoning' (reasoning that accompanies
-the output) `tool-uses' (an alist of tools and their arguments),
-`tool-results' (an alist of results of a calling tools), and
-`text-alternates', a list of alternate possibilities for the output."
+the output) `tool-uses' (a list of plists with tool `:name' and
+`:args'), and `tool-results' (an alist of results of a calling tools)"
   (ignore provider prompt multi-output)
   (signal 'not-implemented nil))
 
@@ -400,9 +399,8 @@ ERROR-CALLBACK receives the error response.
 
 If MULTI-OUTPUT is non-nil the response is a plist with the possible
 keys: `text' (textual output), `reasoning' (reasoning that accompanies
-the output) `tool-uses' (an alist of tools and their arguments),
-`tool-results' (an alist of results of a calling tools), and
-`text-alternates', a list of alternate possibilities for the output.
+the output) `tool-uses' (a list of plists with tool `:name' and
+`:args'), and `tool-results' (an alist of results of a calling tools)
 
 The prompt's interactions list will be updated to encode the
 conversation so far.
@@ -465,8 +463,8 @@ ERROR-CALLBACK receives the error response.
 
 If MULTI-OUTPUT is non-nil the response is a plist with the possible
 keys: `text' (textual output), `reasoning' (reasoning that accompanies
-the output) `tool-results' (an alist of results of a calling tools) and
-`text-alternates', a list of alternate possibilities for the output.
+the output) `tool-uses' (a list of plists with tool `:name' and
+`:args'), and `tool-results' (an alist of results of a calling tools)
 
 The prompt's interactions list will be updated to encode the
 conversation so far.


### PR DESCRIPTION
This adds the `multi-ouput` optional argument to the llm interface.  When set, the return value can contain different types of values: `text`, the normal textual output of the model, `tool-results`, the results of tool calls, `tool-uses` the uses determined by the LLM, from which we execute to get the results, and `reasoning`, the output for reasoning.

This should enable us to solve https://github.com/ahyatt/llm/issues/143, but it may require more work with the r1 server and any other reasoning server.  Other reasoning models didn't appear to have a different output stream, but that may change.
