### PR TITLE
Fix issue in Ollama when passing non-standard params

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,5 @@
+* Version 0.24.1
+- Fix issue with Ollama incorrect requests when passing non-standard params.
 * Version 0.24.0
 - Add =multi-output= as an option, allowing all llm results to return, call, or stream multiple kinds of data via a plist.  This allows separating out reasoning, as well as optionally returning text as well as tool uses at the same time.
 - Added ~llm-models~ to get a list of models from a provider.

--- a/llm-ollama.el
+++ b/llm-ollama.el
@@ -184,8 +184,9 @@ PROVIDER is the llm-ollama provider."
       (when-let* ((keep-alive (plist-get more-options-plist :keep_alive)))
         (setq request-plist (plist-put request-plist :keep_alive keep-alive)))
       (setq options (append options
-                            (map-filter (lambda (key _) (not (equal key :keep_alive)))
-                                        more-options-plist))))
+                            (map-into (map-filter (lambda (key _) (not (equal key :keep_alive)))
+                                                  more-options-plist)
+                                      'plist))))
     (when options
       (setq request-plist (plist-put request-plist :options options)))
     request-plist))


### PR DESCRIPTION
This was introduced in the recent change to handle the `keep-alive` option separately.

This fixes https://github.com/ahyatt/llm/issues/168.