### PR TITLE
Fix Claude tool use with empty arguments (#171)

### DIFF
--- a/llm-claude.el
+++ b/llm-claude.el
@@ -208,9 +208,11 @@ DATA is a vector of lists produced by `llm-provider-streaming-media-handler'."
                        (concat (llm-provider-utils-tool-use-args tool) input)))))
     (maphash (lambda (_ tool)
                (condition-case nil
-                   (setf (llm-provider-utils-tool-use-args tool)
-                         (json-parse-string (llm-provider-utils-tool-use-args tool)
-                                            :object-type 'alist))
+                   (let ((args (llm-provider-utils-tool-use-args tool)))
+                     (setf (llm-provider-utils-tool-use-args tool)
+                           (if (string-empty-p args)
+                               nil
+                             (json-parse-string args :object-type 'alist))))
                  (error nil))
                (push tool result))
              tools)


### PR DESCRIPTION
* (llm-provider-collect-streaming-tool-uses): Handle case where Claude returns the empty string for tool use arguments.