### PR TITLE
Fix bug in streaming with reasoning models

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -2,6 +2,7 @@
 - Call tools with =nil= when called with false JSON values
 - Add Qwen 3 and Gemma 3 to model list.
 - Fix broken model error message
+- Fix reasoning model and streaming incompatibility
 * Version 0.25.0
 - Add =llm-ollama-authed= provider, which is like Ollama but takes a key.
 - Set Gemini 2.5 Pro to be the default Gemini model

--- a/llm-provider-utils.el
+++ b/llm-provider-utils.el
@@ -424,10 +424,11 @@ Any strings will be concatenated, integers will be added, etc."
                     (setq current-result
                           (llm-provider-utils-streaming-accumulate current-result s))
                     (when partial-callback
-                      (llm-provider-utils-callback-in-buffer
-                       buf partial-callback (if multi-output
-                                                current-result
-                                              (plist-get current-result :text)))))
+                      (when-let* ((callback-val (if multi-output
+                                                    current-result
+                                                  (plist-get current-result :text))))
+                        (llm-provider-utils-callback-in-buffer
+                         buf partial-callback callback-val))))
                   (lambda (err)
                     (llm-provider-utils-callback-in-buffer
                      buf error-callback 'error


### PR DESCRIPTION
When only reasoning results have come in, we shouldn't call callbacks with `nil` values when `multi-output` is off.

This will fix https://github.com/ahyatt/ekg/issues/203.