### PR TITLE
Handle string keys in parameter conversion for Open AI

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,6 +1,7 @@
 * Version 0.27.3
 - Add reasoning output for Gemini.
 - Add Claude 4.5 to support models, fix model matching for other Claude models.
+- Fix Open AI issue in using =non-stardard-params=.
 * Version 0.27.2
 - Add JSON response capabilities to Gemini, which had a non-standard API.
 - Add Claude 4.1 to supported models

--- a/llm-openai.el
+++ b/llm-openai.el
@@ -279,7 +279,9 @@ FCS is a list of `llm-provider-utils-tool-use' structs."
           (val (cdr param)))
       (setq request-plist
             (plist-put request-plist
-                       (if (keywordp key) key (intern (concat ":" (symbol-name key))))
+                       (if (keywordp key) key (intern (concat ":" (if (symbolp key)
+                                                                      (symbol-name key)
+                                                                    key))))
                        val)))))
 
 (cl-defmethod llm-provider-chat-request ((provider llm-openai) prompt streaming)


### PR DESCRIPTION
For compatibility, we'll keep the ability for now to send symbols as non-standard-params.

Fixes https://github.com/ahyatt/llm/issues/212