### PR TITLE
Fix a JSON encoding error caused by utf-8 strings for OpenAI, Ollama

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,5 @@
+* Version 0.30.2
+- Fix json encoding error caused by utf-8 strings for Open AI and Ollama
 * Version 0.30.1
 - Fix lack of reasoning response when doing tool calls
 - Added support for Open AI compatible =reasoning_content= and =reasoning= blocks for streaming

--- a/llm-ollama.el
+++ b/llm-ollama.el
@@ -180,7 +180,7 @@ PROVIDER is the llm-ollama provider."
                                                       (if (llm-media-p part)
                                                           ""
                                                         part)))
-                                            (t (json-serialize content))))
+                                            (t (llm-provider-utils-json-serialize content))))
                                         (when images
                                           `(:images
                                             ,(vconcat (mapcar (lambda (img) (base64-encode-string (llm-media-data img) t))

--- a/llm-openai.el
+++ b/llm-openai.el
@@ -259,8 +259,8 @@ FCS is a list of `llm-provider-utils-tool-use' structs."
                    :type "function"
                    :function
                    (:name ,(llm-provider-utils-tool-use-name fc)
-                          :arguments ,(json-serialize
-                                       (llm-provider-utils-tool-use-args fc)))))
+                          :arguments ,(llm-provider-utils-json-serialize
+                                        (llm-provider-utils-tool-use-args fc)))))
            fcs)))
 
 (defun llm-openai--build-messages (prompt)

--- a/llm-openai.el
+++ b/llm-openai.el
@@ -260,7 +260,7 @@ FCS is a list of `llm-provider-utils-tool-use' structs."
                    :function
                    (:name ,(llm-provider-utils-tool-use-name fc)
                           :arguments ,(llm-provider-utils-json-serialize
-                                        (llm-provider-utils-tool-use-args fc)))))
+                                       (llm-provider-utils-tool-use-args fc)))))
            fcs)))
 
 (defun llm-openai--build-messages (prompt)

--- a/llm-provider-utils.el
+++ b/llm-provider-utils.el
@@ -977,5 +977,13 @@ If F is nil, nothing is done."
   (when (and val (not (eq val :null)))
     val))
 
+(defun llm-provider-utils-json-serialize (object)
+  "Serialize OBJECT to a JSON string, ensuring the result is multibyte.
+
+`json-serialize' returns a unibyte string, which can cause issues when
+the result has non-ASCII characters and is embedded into a structure
+that will itself be serialized with `json-serialize'."
+  (decode-coding-string (json-serialize object) 'utf-8))
+
 (provide 'llm-provider-utils)
 ;;; llm-provider-utils.el ends here


### PR DESCRIPTION
The error is that the following doesn't work:

(json-serialize (list :bar (json-serialize '(:foo "☃"))))

This has been reported as a Emacs bug (80793).