### PR TITLE
Fix OpenAI streaming tool calls handling

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,5 +1,6 @@
 * Version 0.30.2
 - Fix json encoding error caused by utf-8 strings for Open AI and Ollama
+- Improved support for Open AI streaming for tool calls, by [Renato Ferreira](https://github.com/renatofdds)
 * Version 0.30.1
 - Fix lack of reasoning response when doing tool calls
 - Added support for Open AI compatible =reasoning_content= and =reasoning= blocks for streaming

--- a/llm-openai.el
+++ b/llm-openai.el
@@ -378,32 +378,6 @@ STREAMING if non-nil, turn on response streaming."
 (cl-defmethod llm-provider-populate-tool-uses ((_ llm-openai) prompt tool-uses)
   (llm-provider-utils-append-to-prompt prompt tool-uses nil 'assistant))
 
-(defun llm-openai--get-partial-chat-response (response)
-  "Return the text in the partial chat response from RESPONSE.
-RESPONSE can be nil if the response is complete."
-  (when response
-    (let* ((choices (assoc-default 'choices response))
-           (delta (when (> (length choices) 0)
-                    (assoc-default 'delta (aref choices 0))))
-           (content-or-call (or (llm-provider-utils-json-val
-                                 (assoc-default 'content delta))
-                                (llm-provider-utils-json-val
-                                 (assoc-default 'tool_calls delta)))))
-      content-or-call)))
-
-(defun llm-openai--get-partial-reasoning-response (response)
-  "Return the reasoning in the partial chat response from RESPONSE.
-RESPONSE can be nil if the response is complete.  This only works for
-Open AI compatible providers that include reasoning in the delta, such
-as oMLX."
-  (when response
-    (let* ((choices (assoc-default 'choices response))
-           (delta (when (> (length choices) 0)
-                    (assoc-default 'delta (aref choices 0)))))
-      (llm-provider-utils-json-val
-       (or (assoc-default 'reasoning delta)
-           (assoc-default 'reasoning_content delta))))))
-
 (cl-defmethod llm-provider-streaming-media-handler ((_ llm-openai) receiver _)
   (cons 'text/event-stream
         (plz-event-source:text/event-stream
@@ -413,19 +387,19 @@ as oMLX."
                        (let ((data (plz-event-source-event-data event)))
                          (unless (equal data "[DONE]")
                            (let ((response-alist (json-parse-string data :object-type 'alist)))
-                             (let ((text-response (llm-openai--get-partial-chat-response
-                                                   response-alist))
-                                   (reasoning-response (llm-openai--get-partial-reasoning-response
-                                                        response-alist)))
-                               (when (or text-response reasoning-response)
-                                 (funcall receiver (append
-                                                    (when text-response
-                                                      (if (stringp text-response)
-                                                          (list :text text-response)
-                                                        (list :tool-uses-raw
-                                                              text-response)))
-                                                    (when reasoning-response
-                                                      (list :reasoning reasoning-response))))))
+                             (when-let* ((choices (assoc-default 'choices response-alist))
+																				 (delta (and (> (length choices) 0)
+																										 (assoc-default 'delta (aref choices 0)))))
+															 (let ((text (llm-provider-utils-json-val (assoc-default 'content delta)))
+																		 (tool-calls (llm-provider-utils-json-val (assoc-default 'tool_calls delta)))
+																		 (reasoning (llm-provider-utils-json-val
+																								 (or (assoc-default 'reasoning delta)
+																										 (assoc-default 'reasoning_content delta)))))
+																 (when-let ((output (append
+																										 (and (not (string-empty-p reasoning)) `(:text ,text))
+																										 (and tool-calls `(:tool-uses-raw ,tool-calls))
+																										 (and (not (string-empty-p reasoning)) `(:reasoning ,reasoning)))))
+																	 (funcall receiver output))))
                              (when-let ((usage (assoc-default 'usage response-alist)))
                                (when (not (eq usage :null))
                                  (funcall receiver

--- a/llm-openai.el
+++ b/llm-openai.el
@@ -388,18 +388,18 @@ STREAMING if non-nil, turn on response streaming."
                          (unless (equal data "[DONE]")
                            (let ((response-alist (json-parse-string data :object-type 'alist)))
                              (when-let* ((choices (assoc-default 'choices response-alist))
-																				 (delta (and (> (length choices) 0)
-																										 (assoc-default 'delta (aref choices 0)))))
-															 (let ((text (llm-provider-utils-json-val (assoc-default 'content delta)))
-																		 (tool-calls (llm-provider-utils-json-val (assoc-default 'tool_calls delta)))
-																		 (reasoning (llm-provider-utils-json-val
-																								 (or (assoc-default 'reasoning delta)
-																										 (assoc-default 'reasoning_content delta)))))
-																 (when-let ((output (append
-																										 (and (not (string-empty-p reasoning)) `(:text ,text))
-																										 (and tool-calls `(:tool-uses-raw ,tool-calls))
-																										 (and (not (string-empty-p reasoning)) `(:reasoning ,reasoning)))))
-																	 (funcall receiver output))))
+										 (delta (and (> (length choices) 0)
+													 (assoc-default 'delta (aref choices 0)))))
+							   (let ((text (llm-provider-utils-json-val (assoc-default 'content delta)))
+									 (tool-calls (llm-provider-utils-json-val (assoc-default 'tool_calls delta)))
+									 (reasoning (llm-provider-utils-json-val
+												 (or (assoc-default 'reasoning delta)
+													 (assoc-default 'reasoning_content delta)))))
+								 (when-let ((output (append
+													 (unless (string-empty-p reasoning) `(:text ,text))
+													 (when tool-calls `(:tool-uses-raw ,tool-calls))
+													 (unless (string-empty-p reasoning) `(:reasoning ,reasoning)))))
+								   (funcall receiver output))))
                              (when-let ((usage (assoc-default 'usage response-alist)))
                                (when (not (eq usage :null))
                                  (funcall receiver

--- a/llm-provider-utils.el
+++ b/llm-provider-utils.el
@@ -710,7 +710,7 @@ This returns a JSON object (a list that can be converted to JSON)."
 
 (defun llm-provider-utils-openai-collect-streaming-tool-uses (data)
   "Read Open AI compatible streaming output DATA to collect tool-uses."
-  (let* ((num-index (+ 1 (assoc-default 'index (aref data 0))))
+  (let* ((num-index (+ 1 (seq-max (seq-map (lambda (tu) (assoc-default 'index tu)) data))))
          (cvec (make-vector num-index nil)))
     (dotimes (i num-index)
       (setf (aref cvec i) (make-llm-provider-utils-tool-use)))


### PR DESCRIPTION
- Accumulated deltas can contain multiple `tool_calls` with increasing `index`
- Streaming delta can contain an empty string `content` alongside a valid `tool_calls`