### PR TITLE
Signal tool call errors for invalid JSON arguments

### DIFF
--- a/llm-openai.el
+++ b/llm-openai.el
@@ -397,10 +397,8 @@ STREAMING if non-nil, turn on response streaming."
               (make-llm-provider-utils-tool-use
                :id (assoc-default 'id call)
                :name (assoc-default 'name tool)
-               :args (json-parse-string
-                      (let ((args (assoc-default 'arguments tool)))
-                        (if (= (length args) 0) "{}" args))
-                      :object-type 'alist))))
+               :args (llm-provider-utils-parse-openai-tool-arguments
+                      (assoc-default 'arguments tool)))))
           (assoc-default 'tool_calls
                          (assoc-default 'message
                                         (aref (assoc-default 'choices response) 0)))))

--- a/llm-provider-utils-test.el
+++ b/llm-provider-utils-test.el
@@ -60,6 +60,27 @@
                   :required ["location"])))
     (should (equal result expected))))
 
+(ert-deftest llm-provider-utils-parse-openai-tool-arguments ()
+  (should (equal (llm-provider-utils-parse-openai-tool-arguments "")
+                 nil))
+  (should (equal (llm-provider-utils-parse-openai-tool-arguments
+                  "{\"content\":\"├── research_plan.md\"}")
+                 '((content . "├── research_plan.md"))))
+  (should-error
+   (llm-provider-utils-parse-openai-tool-arguments
+    "{\"content\":\"├── research_plan.md\"")
+   :type 'llm-tool-call-error))
+
+(ert-deftest llm-provider-utils-openai-collect-streaming-tool-uses-invalid-json ()
+  (should-error
+   (llm-provider-utils-openai-collect-streaming-tool-uses
+    [((index . 0)
+      (id . "call_1")
+      (function
+       (name . "write_file")
+       (arguments . "{\"content\":\"├── research_plan.md\"")))])
+   :type 'llm-tool-call-error))
+
 (ert-deftest llm-provider-utils-convert-to-serializable ()
   (should (equal (llm-provider-utils-convert-to-serializable '(:a 1 :b 2))
                  '(:a 1 :b 2)))

--- a/llm-provider-utils.el
+++ b/llm-provider-utils.el
@@ -715,7 +715,7 @@ Signal `llm-tool-call-error' when ARGUMENTS is not valid JSON."
       (json-parse-string
        (if (or (null arguments) (= (length arguments) 0)) "{}" arguments)
        :object-type 'alist)
-    (error
+    ((json-parse-error json-end-of-file)
      (signal 'llm-tool-call-error
              (list
               (format "Invalid JSON in tool call arguments: %s"

--- a/llm-provider-utils.el
+++ b/llm-provider-utils.el
@@ -708,6 +708,19 @@ This returns a JSON object (a list that can be converted to JSON)."
                  :parameters ,(llm-provider-utils-openai-arguments
                                (llm-tool-args tool)))))
 
+(defun llm-provider-utils-parse-openai-tool-arguments (arguments)
+  "Parse Open AI compatible tool call ARGUMENTS.
+Signal `llm-tool-call-error' when ARGUMENTS is not valid JSON."
+  (condition-case err
+      (json-parse-string
+       (if (or (null arguments) (= (length arguments) 0)) "{}" arguments)
+       :object-type 'alist)
+    (error
+     (signal 'llm-tool-call-error
+             (list
+              (format "Invalid JSON in tool call arguments: %s"
+                      (error-message-string err)))))))
+
 (defun llm-provider-utils-openai-collect-streaming-tool-uses (data)
   "Read Open AI compatible streaming output DATA to collect tool-uses."
   (let* ((num-index (+ 1 (seq-max (seq-map (lambda (tu) (assoc-default 'index tu)) data))))
@@ -729,8 +742,8 @@ This returns a JSON object (a list that can be converted to JSON)."
                              arguments))))
     (cl-loop for call in (append cvec nil)
              do (setf (llm-provider-utils-tool-use-args call)
-                      (json-parse-string (llm-provider-utils-tool-use-args call)
-                                         :object-type 'alist))
+                      (llm-provider-utils-parse-openai-tool-arguments
+                       (llm-provider-utils-tool-use-args call)))
              finally return (when (> (length cvec) 0)
                               (append cvec nil)))))
 


### PR DESCRIPTION
OpenAI-compatible providers currently parse tool call arguments with raw
`json-parse-string` in both normal and streaming paths. When a model emits
malformed JSON for a tool call, that raw JSON parser error escapes instead of
being classified as `llm-tool-call-error`, so clients cannot use the existing
tool-call retry/error handling path.

This change adds a shared `llm-provider-utils-parse-openai-tool-arguments`
helper that treats empty arguments as an empty object and signals
`llm-tool-call-error` when argument JSON is malformed. Both normal OpenAI tool
extraction and streaming OpenAI-compatible tool collection use the helper.

Tests cover valid non-ASCII arguments and malformed JSON in the streaming path.
