### PR TITLE
Add GPT-6.0 Astra and Gemini 3.8 Flash models

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,6 @@
+* Version 0.32.1
+- Added tool IDs to Ollama streaming for better context-keeping
+- Add GPT 6.0 Astra, Gemini 3.8 Flash (now the default)
 * Version 0.32.0
 - Use success callback when there is partial tool call success, with multi-output =:errors= key
 - Always add errors to the prompt after tool calling

--- a/llm-gemini.el
+++ b/llm-gemini.el
@@ -40,7 +40,7 @@
                                    default-chat-non-standard-params
                                    ((:key raw-key))
                                    (embedding-model "gemini-embedding-001")
-                                   (chat-model "gemini-3.7-flash")
+                                   (chat-model "gemini-3.8-flash")
                                    &aux
                                    (key (llm-provider-utils--wrap-key raw-key)))))
   "A struct representing a Gemini client.

--- a/llm-models.el
+++ b/llm-models.el
@@ -48,6 +48,11 @@ REGEX is a regular expression that can be used to identify the model, uniquely (
   (list
    ;; https://platform.openai.com/docs/models
    (make-llm-model
+    :name "GPT-6 Astra" :symbol 'gpt-6-astra
+    :capabilities '(generation tool-use image-input json-response reasoning)
+    :context-length 1050000
+    :regex (rx (seq "gpt-6-astra")))
+   (make-llm-model
     :name "GPT-5.6 Sol" :symbol 'gpt-5-6-sol
     :capabilities '(generation tool-use image-input json-response reasoning)
     :context-length 1000000
@@ -216,6 +221,12 @@ REGEX is a regular expression that can be used to identify the model, uniquely (
     :context-length 200000
     :regex "claude-opus-4-5")
    ;; https://ai.google.dev/gemini-api/docs/models/gemini
+   (make-llm-model
+    :name "Gemini 3.8 Flash" :symbol 'gemini-3-8-flash
+    :capabilities '(generation tool-use image-input audio-input video-input json-response
+                               pdf-input caching reasoning)
+    :context-length 1048576
+    :regex "gemini-3\\.8-flash")
    (make-llm-model
     :name "Gemini 3.7 Flash" :symbol 'gemini-3-7-flash
     :capabilities '(generation tool-use image-input audio-input video-input json-response


### PR DESCRIPTION
Make Gemini 3.8 Flash the new default for Gemini.