### PR TITLE
Respect OpenAI model reasoning defaults

### DIFF
--- a/llm-openai.el
+++ b/llm-openai.el
@@ -395,20 +395,18 @@ we need to check for a model post 5.2 (if it supports reasoning at all)."
                    (>= (cdr major-minor) 2)))))))
 
 (cl-defmethod llm-openai--build-reasoning ((provider llm-openai) prompt)
-  (when (llm-openai--supports-reasoning provider)
-    (if (llm-chat-prompt-reasoning prompt)
-        (list :reasoning
-              (list :summary "auto"
-                    :effort
-                    (pcase (llm-chat-prompt-reasoning prompt)
-                      ('none "none")
-                      ('light "low")
-                      ('medium "medium")
-                      ('maximum "xhigh")
-                      (_ (signal 'llm-not-supported
-                                 (list (format "Unknown reasoning effort option: %s"
-                                               (llm-chat-prompt-reasoning prompt))))))))
-      '(:reasoning (:summary "auto" :effort "medium")))))
+  (when (and (llm-openai--supports-reasoning provider) (llm-chat-prompt-reasoning prompt))
+    (list :reasoning
+      (list :summary "auto"
+            :effort
+            (pcase (llm-chat-prompt-reasoning prompt)
+              ('none "none")
+              ('light "low")
+              ('medium "medium")
+              ('maximum "xhigh")
+              (_ (signal 'llm-not-supported
+                         (list (format "Unknown reasoning effort option: %s"
+                                       (llm-chat-prompt-reasoning prompt))))))))))
 
 (defun llm-openai--responses-api-build-messages (prompt)
   "Build the :messages field based on interactions in PROMPT."


### PR DESCRIPTION
Instead of passing a default effort when user has not supplied one,
simply skip it.

This is valid according to the responses api:
https://developers.openai.com/api/docs/guides/reasoning

Especially this part is important I guess:

> Defaults are also model-dependent rather than universal. gpt-5.5
> defaults to medium reasoning effort. This is the best starting point
> for gpt-5.5’s full balance of quality, reliability and performance.

This way, we also enable the users to depend on API default defaults
instead of forcing medium. This also aligns with the implementation of
`llm-openai--build-reasoning` currently in `llm-deepseek.el`.

Fixes #300 